### PR TITLE
updates to Homebrew command syntax

### DIFF
--- a/_mac/homebrew.md
+++ b/_mac/homebrew.md
@@ -18,7 +18,7 @@ Installing Homebrew is straightforward as long as you understand the Mac Termina
 
 ## Installation Steps
 * **Open the Terminal app**.
-* **Type** `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"` You'll see messages in the Terminal explaining what you need to do to complete the installation process. You can learn more about Homebrew at the [Homebrew website](http://brew.sh/).
+* **Type** `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"` You'll see messages in the Terminal explaining what you need to do to complete the installation process. You can learn more about Homebrew at the [Homebrew website](http://brew.sh/).
 
 ## How to Update Homebrew
 New versions of Homebrew come out frequently, so make sure you update it before updating any of the other software components that you've installed using Homebrew.


### PR DESCRIPTION
Still a very useful handy guide in 2020, got this little warning though, might need a small update to this command syntax? 

`% ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in Bash. Please migrate to the following command:
`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`