### PR TITLE
Update Mac Homebrew guide to current bash script

### DIFF
--- a/_mac/homebrew.md
+++ b/_mac/homebrew.md
@@ -18,7 +18,7 @@ Installing Homebrew is straightforward as long as you understand the Mac Termina
 
 ## Installation Steps
 * **Open the Terminal app**.
-* **Type** `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"` You'll see messages in the Terminal explaining what you need to do to complete the installation process. You can learn more about Homebrew at the [Homebrew website](http://brew.sh/).
+* **Type** `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` You'll see messages in the Terminal explaining what you need to do to complete the installation process. You can learn more about Homebrew at the [Homebrew website](http://brew.sh/).
 
 ## How to Update Homebrew
 New versions of Homebrew come out frequently, so make sure you update it before updating any of the other software components that you've installed using Homebrew.


### PR DESCRIPTION
Committer: Brett Packard <brettjayp>

Homebrew's script to install on Mac changed from Ruby to Bash, as indicated when attempting to install through the [current installation guide from Treehouse](https://treehouse.github.io/installation-guides/mac/homebrew) (see terminal output below). Changes made here update the page with the current Bash script provided by Homebrew team.

```
[user] % ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```