### PR TITLE
Redirect links to corresponding post on treehouse blog

### DIFF
--- a/_mac/homebrew.md
+++ b/_mac/homebrew.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title:  "Installing Homebrew on a Mac"
+title:  "Installing Homebrew on Mac"
 date:   2016-05-14 13:31:00
 categories: mac
 ---

--- a/_mac/mongo-mac.md
+++ b/_mac/mongo-mac.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title:  "Installing MongoDB on a Mac"
+title:  "Installing MongoDB on Mac"
 date:   2015-12-28 12:00:00
 categories: mac
 ---
@@ -11,11 +11,11 @@ This is different than SQL databases like MySQL and PostgreSQL, where fields cor
 
 ## Prerequisites
 * **You should have some familiarity with the Mac Terminal application** since you'll need to use it to install and run MongoDB.
-* **Dependencies.** This guide goes over the two main ways to install MongoDB on a Mac.  One of the methods requires Homebrew.
-  * **Homebrew**. Homebrew is a package manager for the Mac -- it makes installing most open source software (like MongoDB) as simple as writing `brew install mongodb`. Follow the instructions in the [How to Install Homebrew on a Mac](homebrew) instruction guide.
+* **Dependencies.** This guide goes over the two main ways to install MongoDB on Mac.  One of the methods requires Homebrew.
+  * **Homebrew**. Homebrew is a package manager for the Mac -- it makes installing most open source software (like MongoDB) as simple as writing `brew install mongodb`. Follow the instructions in the [How to Install Homebrew on Mac](homebrew) instruction guide.
 
 ## Installation Overview
-There are two primary ways to install MongoDB on a Mac.  The best way to install MongoDB is with Homebrew.  The other way to install MongoDB is by downloading it from the the [MongoDB website](https://www.mongodb.org/downloads#production).
+There are two primary ways to install MongoDB on Mac.  The best way to install MongoDB is with Homebrew.  The other way to install MongoDB is by downloading it from the the [MongoDB website](https://www.mongodb.org/downloads#production).
 
 ## Install and Run MongoDB with Homebrew
 * **Open the Terminal app** and type `brew update`.

--- a/_mac/node-mac.md
+++ b/_mac/node-mac.md
@@ -11,12 +11,12 @@ NPM is a "package manager" that makes installing Node "packages" fast and easy. 
 
 NPM is installed when you install Node.js®
 
-Although there is a Mac installer program on the Node website, we recommend using Homebrew to install and update Node.  
+Although there is Mac installer program on the Node website, we recommend using Homebrew to install and update Node.  
 
 ## Prerequisites
 * **You should have some familiarity with the Mac Terminal application** since you'll need to use it to install and test Node and NPM. You'll also need the Terminal to use Node.js and NPM. The Terminal application is located in the Utilities folder in the Applications folder.
 * **Dependencies.** Although you can install Node in other ways, we recommend using Homebrew. Homebrew lets you avoid possible security problems associated with using the `sudo` command to install software like Node and Node modules.
-  * **Install Homebrew**. Follow the steps on the [How to Install Homebrew on a Mac](homebrew) instruction guide to install Homebrew. 
+  * **Install Homebrew**. Follow the steps on the [How to Install Homebrew on Mac](homebrew) instruction guide to install Homebrew. 
 
 ## Installation Overview
 Installing Node.js® and NPM is pretty straightforward using Homebrew. Homebrew handles downloading, unpacking and installing Node and NPM on your system. The whole process (after you have Homebrew installed) should only take you a few minutes.

--- a/_site/mac/homebrew.html
+++ b/_site/mac/homebrew.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Installing Homebrew on a Mac</title>
+  <title>Installing Homebrew on Mac</title>
   <meta name="description" content="InstallationHomebrew is package manager for Macs which makes installing lots of different software like Git, Ruby, and Node simpler. Homebrew lets you avoid ...">
 
   <link rel="stylesheet" href="/installation-guides/css/main.css">
@@ -57,7 +57,7 @@
         <div class="post">
 
   <header class="post-header">
-    <h1 class="post-title">Installing Homebrew on a Mac</h1>
+    <h1 class="post-title">Installing Homebrew on Mac</h1>
   </header>
 
   <article class="post-content">

--- a/_site/mac/node-mac.html
+++ b/_site/mac/node-mac.html
@@ -75,7 +75,7 @@
   <li><strong>You should have some familiarity with the Mac Terminal application</strong> since you’ll need to use it to install and test Node and NPM. You’ll also need the Terminal to use Node.js and NPM. The Terminal application is located in the Utilities folder in the Applications folder.</li>
   <li><strong>Dependencies.</strong> Although you can install Node in other ways, we recommend using Homebrew. Homebrew lets you avoid possible security problems associated with using the <code class="highlighter-rouge">sudo</code> command to install software like Node and Node modules.
     <ul>
-      <li><strong>Install Homebrew</strong>. Follow the steps on the <a href="homebrew">How to Install Homebrew on a Mac</a> instruction guide to install Homebrew.</li>
+      <li><strong>Install Homebrew</strong>. Follow the steps on the <a href="homebrew">How to Install Homebrew on Mac</a> instruction guide to install Homebrew.</li>
     </ul>
   </li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -4,11 +4,14 @@ layout: default
 
 <div class="home">
 
+  {% assign blog_url = "https://blog.teamtreehouse.com/" %}
+
   <ul class="post-list">
   <li><h2>Windows</h2>
     <ul>
       {% for guide in site.windows %}
-        <li><a href="{{ site.baseurl }}{{ guide.url }}">{{ guide.title }}</a></li>
+        {% assign slug = guide.title | downcase | remove: "®" | replace: ".", "-" | replace: " ", "-" %}
+        <li><a href="{{ blog_url }}{{ slug }}" target="_blank">{{ guide.title }}</a></li>
       {% endfor %}
     </ul>
   </li>
@@ -17,7 +20,8 @@ layout: default
   <li><h2>Mac</h2>
     <ul>
       {% for guide in site.mac %}
-        <li><a href="{{ site.baseurl }}{{ guide.url }}">{{ guide.title }}</a></li>
+        {% assign slug = guide.title | downcase | remove: "®" | replace: ".", "-" | replace: " ", "-" %}
+        <li><a href="{{ blog_url }}{{ slug }}" target="_blank">{{ guide.title }}</a></li>
       {% endfor %}
     </ul>
   </li>
@@ -26,12 +30,13 @@ layout: default
   <li><h2>Linux</h2>
     <ul>
       {% for guide in site.linux %}
-        <li><a href="{{ site.baseurl }}{{ guide.url }}">{{ guide.title }}</a></li>
+        {% assign slug = guide.title | downcase | remove: "®" | replace: ".", "-" | replace: " ", "-" %}
+        <li><a href="{{ blog_url }}{{ slug }}" target="_blank">{{ guide.title }}</a></li>
       {% endfor %}
     </ul>
   </li>
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+  <p class="rss-subscribe">subscribe <a href="{{ '/feed.xml' | prepend: site.baseurl }}">via RSS</a></p>
 
 </div>


### PR DESCRIPTION
[ticket](https://teamtreehouse.atlassian.net/browse/TH-206?atlOrigin=eyJpIjoiMDYxMzRkNmVkYWVhNGM1MWExYmNhOGExNzJlMjkwZWMiLCJwIjoiaiJ9)

What:
Update link to direct to corresponding blog post using the guide.title as slug.
Removed the particle "a" for consistency.

Test:
`jekyll serve`
go to localhost:4000/installation-guides/
and click on the links.
